### PR TITLE
Feature/rootleveljson

### DIFF
--- a/pq/parser.go
+++ b/pq/parser.go
@@ -24,6 +24,13 @@ func Parse(in string) (*Query, error) {
 
 	exprs := []Expression{&CurrentAccess{}}
 
+	// Special case for root-level query "."
+	if in == "." {
+		return &Query{
+			Elements: exprs,
+		}, nil
+	}
+
 	fieldName := fieldRegex.FindString(in)
 	if fieldName == "" {
 		return nil, newParserError(in, "query must have field name after accessor '.'")

--- a/pq/parser_test.go
+++ b/pq/parser_test.go
@@ -15,6 +15,12 @@ func TestParse(t *testing.T) {
 		assertion require.ErrorAssertionFunc
 	}{
 		{
+			"root query",
+			".",
+			&Query{[]Expression{&CurrentAccess{}}},
+			require.NoError,
+		},
+		{
 			"current with field with array",
 			".fieldName[]",
 			&Query{[]Expression{&CurrentAccess{}, &FieldAccess{Name: "fieldName"}, &ArrayAccess{}}},

--- a/pq/query_test.go
+++ b/pq/query_test.go
@@ -4,67 +4,111 @@ import (
 	"testing"
 
 	"github.com/jhump/protoreflect/desc"
-	pbtest "github.com/streamingfast/substreams-sink-files/pq/testdata"
-	"github.com/stretchr/testify/assert"
+	"github.com/jhump/protoreflect/desc/builder"
+	"github.com/jhump/protoreflect/dynamic"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestQuery_Resolve(t *testing.T) {
-	t.Skip("fix test to reflect library change")
-	transfer := func(value uint64) *pbtest.Transfer {
-		return &pbtest.Transfer{Value: 1}
+	// Helper function to create test data using completely independent descriptors
+	createTransfersData := func(transferValues ...uint64) ([]byte, *desc.MessageDescriptor, error) {
+		// Create completely independent descriptors using builder
+		// This avoids any association with the compiled Go types
+
+		// Create Transfer message descriptor
+		transferBuilder := builder.NewMessage("Transfer")
+		transferBuilder.AddField(builder.NewField("value", builder.FieldTypeUInt64()).SetNumber(1))
+		transferDesc, err := transferBuilder.Build()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Create Transfers message descriptor
+		transfersBuilder := builder.NewMessage("Transfers")
+		transfersBuilder.AddField(builder.NewField("transfers", builder.FieldTypeImportedMessage(transferDesc)).SetRepeated().SetNumber(1))
+		transfersDesc, err := transfersBuilder.Build()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Create dynamic message factory
+		factory := dynamic.NewMessageFactoryWithDefaults()
+
+		// Create dynamic transfers message
+		transfersMsg := factory.NewDynamicMessage(transfersDesc)
+
+		// Create and add transfer messages
+		for _, value := range transferValues {
+			transferMsg := factory.NewDynamicMessage(transferDesc)
+			transferMsg.SetFieldByNumber(1, value)                // value field
+			transfersMsg.AddRepeatedFieldByNumber(1, transferMsg) // transfers field
+		}
+
+		// Marshal to bytes
+		bytes, err := transfersMsg.Marshal()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return bytes, transfersDesc, nil
 	}
 
-	type args struct {
-		root  *pbtest.Transfers
-		query string
-	}
-	tests := []struct {
+	type testCase struct {
 		name      string
-		args      args
-		want      []proto.Message
+		query     string
+		wantCount int
+		testData  []uint64
 		assertion require.ErrorAssertionFunc
-	}{
+	}
+	tests := []testCase{
 		{
 			"empty",
-			args{&pbtest.Transfers{}, ".transfers[]"},
-			nil,
+			".transfers[]",
+			0,
+			[]uint64{},
 			require.NoError,
 		},
 		{
 			"single element",
-			args{&pbtest.Transfers{Transfers: []*pbtest.Transfer{transfer(1)}}, ".transfers[]"},
-			[]proto.Message{transfer(1)},
+			".transfers[]",
+			1,
+			[]uint64{1},
 			require.NoError,
 		},
 		{
 			"multi elements",
-			args{&pbtest.Transfers{Transfers: []*pbtest.Transfer{transfer(1), transfer(2)}}, ".transfers[]"},
-			[]proto.Message{transfer(1), transfer(2)},
+			".transfers[]",
+			2,
+			[]uint64{1, 2},
 			require.NoError,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			query, err := Parse(tt.args.query)
+			query, err := Parse(tt.query)
 			require.NoError(t, err)
 
-			bytes, err := proto.Marshal(tt.args.root)
-			require.NoError(t, err)
-
-			descriptor, err := desc.LoadMessageDescriptorForMessage(tt.args.root)
+			bytes, descriptor, err := createTransfersData(tt.testData...)
 			require.NoError(t, err)
 
 			got, err := query.Resolve(bytes, descriptor)
 			tt.assertion(t, err)
 
-			require.Len(t, got, len(tt.want))
-			//for i, want := range tt.want {
-			//	assertProtoEqual(t, want, got[i], "at index %d", i)
-			//}
+			require.Len(t, got, tt.wantCount)
 
-			assert.Equal(t, tt.want, got)
+			// Verify that we got dynamic messages back
+			for j, msg := range got {
+				require.NotNil(t, msg, "message at index %d should not be nil", j)
+				// Verify it's a dynamic message by checking we can get field value
+				if tt.wantCount > 0 {
+					value, err := msg.TryGetFieldByNumber(1) // value field
+					require.NoError(t, err)
+					require.NotNil(t, value, "value field should not be nil at index %d", j)
+					// Verify the value matches what we put in
+					require.Equal(t, tt.testData[j], value.(uint64), "value should match at index %d", j)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add support for `protojson:.` path, to allow writing json files from protobuf messages that do not contain any repeated field.