### PR TITLE
switch to encoding/protojson lib instead of 'json', prep release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.0.1
+
+### **Breaking Changes**
+
+* `protojson:` and `proto` outputs now use the `google.golang.org/protobuf/encoding/protojson` library to ensure it follows the correct definition (https://protobuf.dev/programming-guides/json/)
+
+### Deprecation Warning
+
+* Using this package binary will soon be deprecated in favor of the `substreams sink parquet` and `substreams sink protojson` commands.
+
 ## v3.0.0
 
 ### **Breaking Changes**

--- a/cmd/substreams-sink-files/tools.go
+++ b/cmd/substreams-sink-files/tools.go
@@ -47,7 +47,7 @@ func toolsParquetSchemaE(cmd *cobra.Command, args []string) error {
 	sinker, err := sink.New(sink.SubstreamsModeProduction, true, pkg, module, outputModuleHash, nil, zlog, tracer)
 	cli.NoError(err, "New sinker failed")
 
-	descriptor, err := outputProtoreflectMessageDescriptor(sinker)
+	descriptor, err := outputMessageDescriptor(sinker)
 	cli.NoError(err, "Failed to extract message descriptor from output module")
 
 	parquetWriterOptions, err := writer.NewParquetWriterOptions(readCommonParquetFlags(cmd).AsParquetWriterOptions())

--- a/encoder/proto_to_json_test.go
+++ b/encoder/proto_to_json_test.go
@@ -2,14 +2,6 @@ package encoder
 
 import (
 	"testing"
-
-	anypbLegacy "github.com/golang/protobuf/ptypes/any"
-	"github.com/jhump/protoreflect/desc"
-	"github.com/jhump/protoreflect/dynamic"
-	pbtest "github.com/streamingfast/substreams-sink-files/encoder/testdata"
-	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/test-go/testify/require"
 )
 
 func TestProtoToJson_EncodeTo(t *testing.T) {
@@ -19,86 +11,88 @@ func TestProtoToJson_EncodeTo(t *testing.T) {
 		"actual message. I was not able to replicate using a simpler setup where I control the" +
 		"proto message. Would need to see how Substreams package the proto to replicate same patter")
 
-	transfer := func(value uint64) *pbtest.Transfer {
-		return &pbtest.Transfer{Value: 1}
-	}
-
-	tests := []struct {
-		name      string
-		entities  *pbtest.Transfers
-		expected  []byte
-		assertion assert.ErrorAssertionFunc
-	}{
-		{
-			"zero transfer",
-			&pbtest.Transfers{
-				Transfers: nil,
-			},
-			nil,
-			assert.NoError,
-		},
-		{
-			"one transfer",
-			&pbtest.Transfers{
-				Transfers: []*pbtest.Transfer{
-					transfer(1),
-				},
-			}, []byte(`{"a":1}`),
-			assert.NoError,
-		},
-		// {
-		// 	"three line",
-		// 	&pbfilesink.Lines{Lines: [][]byte{
-		// 		[]byte(`{"a":1}`),
-		// 		[]byte(`{"b":2}`),
-		// 		[]byte(`{"c":3}`),
-		// 	}},
-		// 	[]byte(`{"a":1}` + "\n" + `{"b":2}` + "\n" + `{"c":3}`),
-		// 	assert.NoError,
-		// },
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// desc.LoadMessageDescriptor(tt.entities.Desc)
-
-			dynamicMsg, err := dynamic.AsDynamicMessage(tt.entities)
-			require.NoError(t, err)
-
-			descriptor, err := desc.LoadMessageDescriptorForMessage(dynamicMsg)
-			require.NoError(t, err)
-
-			tt.entities.ProtoReflect().Descriptor()
-
-			msg := dynamic.NewMessage(descriptor)
-			msg.Merge(tt.entities)
-
-			descriptor2, err := desc.LoadMessageDescriptorForMessage(msg)
-			require.NoError(t, err)
-
-			encoder, err := NewProtoToJson(".transfers[]", descriptor2)
-			require.NoError(t, err)
-
-			writer := &testWriter{}
-
-			// out, err := protoLegacy.Marshal(tt.entities)
-			// require.NoError(t, err)
-
-			// fmt.Println("Hex", hex.EncodeToString(out))
-
-			// output, err := anypb.New(tt.entities)
-			// require.NoError(t, err)
-
-			test := &anypbLegacy.Any{
-				TypeUrl: "test",
-				Value:   []byte{0x0a, 0x02, 0x08, 0x01},
-			}
-
-			module := &pbsubstreamsrpc.MapModuleOutput{
-				MapOutput: test,
-			}
-
-			tt.assertion(t, encoder.EncodeTo(module, writer))
-			assert.Equal(t, tt.expected, writer.written)
-		})
-	}
+	//	transfer := func(value uint64) *pbtest.Transfer {
+	//		return &pbtest.Transfer{Value: 1}
+	//	}
+	//
+	//	tests := []struct {
+	//		name      string
+	//		entities  *pbtest.Transfers
+	//		expected  []byte
+	//		assertion assert.ErrorAssertionFunc
+	//	}{
+	//
+	//		{
+	//			"zero transfer",
+	//			&pbtest.Transfers{
+	//				Transfers: nil,
+	//			},
+	//			nil,
+	//			assert.NoError,
+	//		},
+	//		{
+	//			"one transfer",
+	//			&pbtest.Transfers{
+	//				Transfers: []*pbtest.Transfer{
+	//					transfer(1),
+	//				},
+	//			}, []byte(`{"a":1}`),
+	//			assert.NoError,
+	//		},
+	//		// {
+	//		// 	"three line",
+	//		// 	&pbfilesink.Lines{Lines: [][]byte{
+	//		// 		[]byte(`{"a":1}`),
+	//		// 		[]byte(`{"b":2}`),
+	//		// 		[]byte(`{"c":3}`),
+	//		// 	}},
+	//		// 	[]byte(`{"a":1}` + "\n" + `{"b":2}` + "\n" + `{"c":3}`),
+	//		// 	assert.NoError,
+	//		// },
+	//	}
+	//
+	//	for _, tt := range tests {
+	//		t.Run(tt.name, func(t *testing.T) {
+	//			// desc.LoadMessageDescriptor(tt.entities.Desc)
+	//
+	//			dynamicMsg, err := dynamic.AsDynamicMessage(tt.entities)
+	//			require.NoError(t, err)
+	//
+	//			descriptor, err := desc.LoadMessageDescriptorForMessage(dynamicMsg)
+	//			require.NoError(t, err)
+	//
+	//			tt.entities.ProtoReflect().Descriptor()
+	//
+	//			msg := dynamic.NewMessage(descriptor)
+	//			msg.Merge(tt.entities)
+	//
+	//			descriptor2, err := desc.LoadMessageDescriptorForMessage(msg)
+	//			require.NoError(t, err)
+	//
+	//			encoder, err := NewProtoToJson(".transfers[]", descriptor2)
+	//			require.NoError(t, err)
+	//
+	//			writer := &testWriter{}
+	//
+	//			// out, err := protoLegacy.Marshal(tt.entities)
+	//			// require.NoError(t, err)
+	//
+	//			// fmt.Println("Hex", hex.EncodeToString(out))
+	//
+	//			// output, err := anypb.New(tt.entities)
+	//			// require.NoError(t, err)
+	//
+	//			test := &anypbLegacy.Any{
+	//				TypeUrl: "test",
+	//				Value:   []byte{0x0a, 0x02, 0x08, 0x01},
+	//			}
+	//
+	//			module := &pbsubstreamsrpc.MapModuleOutput{
+	//				MapOutput: test,
+	//			}
+	//
+	//			tt.assertion(t, encoder.EncodeTo(module, writer))
+	//			assert.Equal(t, tt.expected, writer.written)
+	//		})
+	//	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/bobg/go-generics/v2 v2.2.2
 	github.com/holiman/uint256 v1.3.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/jhump/protoreflect v1.14.0
 	github.com/parquet-go/parquet-go v0.23.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -49,6 +48,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/jhump/protoreflect v1.14.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
@@ -100,7 +100,7 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.4
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect


### PR DESCRIPTION
* switch to encoding/protojson for encoding instead of encoding/json
* switch to google.golang.org/protobuf/reflect/protoreflect instead of github.com/jhump/protoreflect
* prep release 3.0.1
* mark binary deprecation in favor of upcoming 'substreams sink parquet/protojson' commands